### PR TITLE
Feature improved gm performance

### DIFF
--- a/application/gui/game_manager_window.py
+++ b/application/gui/game_manager_window.py
@@ -56,6 +56,23 @@ class GameManagerWindow(QMainWindow):
 
         self._initialized = True
 
+    def closeEvent(self, event):
+        self._game_manager_widget.stop_timer()
+        self._game_manager_widget.hide()
+
+    def showWindow(self):
+        # Wrapping the show method so the timer can be started, if it isn't already in
+        # addition to calling show()
+        self._game_manager_widget.start_timer(
+            override_interval=self._game_manager_widget.FAST_INTERVAL
+        )
+        self._game_manager_widget.show()
+        self.show()
+
+    def forTest(self):
+        self._game_manager_widget.show()
+        self.show()
+
     def add_widget_items(self):
         self._main_widget = QWidget(self)
 

--- a/application/gui/game_manager_window.py
+++ b/application/gui/game_manager_window.py
@@ -69,10 +69,6 @@ class GameManagerWindow(QMainWindow):
         self._game_manager_widget.show()
         self.show()
 
-    def forTest(self):
-        self._game_manager_widget.show()
-        self.show()
-
     def add_widget_items(self):
         self._main_widget = QWidget(self)
 

--- a/application/gui/launch.py
+++ b/application/gui/launch.py
@@ -73,8 +73,10 @@ class GuiApp:
         if not self._game_manager_window._initialized:
             self._game_manager_window.init_ui()
         else:
+            self._game_manager_window.forTest()
             self._game_manager_window.update()
-        self._game_manager_window.show()
+
+        self._game_manager_window.showWindow()
 
     def _launch_new_game_window(self):
         if not self._game_install_window._initialized:

--- a/application/gui/launch.py
+++ b/application/gui/launch.py
@@ -73,7 +73,6 @@ class GuiApp:
         if not self._game_manager_window._initialized:
             self._game_manager_window.init_ui()
         else:
-            self._game_manager_window.forTest()
             self._game_manager_window.update()
 
         self._game_manager_window.showWindow()

--- a/application/gui/widgets/game_manager_widget.py
+++ b/application/gui/widgets/game_manager_widget.py
@@ -322,9 +322,7 @@ class GameManagerWidget(QWidget):
         return game_frame
 
     def _text_changed(self, game_pretty_name):
-        logger.info("+++++++++++++++++++++++++++++++++++++++++++++")
-        logger.info(f"Curent Game changed to: {game_pretty_name}")
-        logger.info("+++++++++++++++++++++++++++++++++++++++++++++")
+        logger.debug(f"Curent Game changed to: {game_pretty_name}")
 
         if game_pretty_name == "":
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ requests
 validators==0.20.0
 vdf==3.4
 
+# TODO - Eventually this should be a specific version.
 operator @ git+https://github.com/agentsofthesystem/operator@main


### PR DESCRIPTION
The Game Manager Window was causing performance slow downs.  It's designed to be basic on purpose so it uses a timer to refresh the GUI/Widget.  That refresh would happen whether or not the window was open, so some improvements were made so that the refresh logic doesn't run while the window is closed.  Making this change revealed some other bugs, so those were corrected at the same time. 