### PR TITLE
Support Default App Install & Arg Paths.

### DIFF
--- a/application/api/v1/blueprints/access.py
+++ b/application/api/v1/blueprints/access.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from flask import Blueprint, current_app, request, jsonify
 from oauthlib.oauth2 import RequestValidator
 
-from application.common import logger
+from application.common import logger, constants
 from application.common.authorization import _verify_bearer_token
 from application.common.decorators import authorization_required
 from application.common.exceptions import InvalidUsage
@@ -56,7 +56,9 @@ def token_generate():
     if token_obj:
         raise InvalidUsage("Error: Token by that name already exists!", status_code=400)
 
-    secret_obj = Settings.query.filter_by(setting_name="application_secret").first()
+    secret_obj = Settings.query.filter_by(
+        setting_name=constants.SETTING_NAME_APP_SECRET
+    ).first()
     validator = TokenValidator(secret_obj.setting_value, current_app.config["APP_NAME"])
 
     computed_token = validator.generate_access_token(new_token_name)

--- a/application/common/authorization.py
+++ b/application/common/authorization.py
@@ -2,6 +2,7 @@ import jwt
 
 from flask.wrappers import Request
 
+from application.common import constants
 from application.source.models.settings import Settings
 from application.source.models.tokens import Tokens
 
@@ -32,7 +33,9 @@ def _verify_bearer_token(request: Request) -> int:
         return 403
 
     # Next decode this bad thing...
-    secret_obj = Settings.query.filter_by(setting_name="application_secret").first()
+    secret_obj = Settings.query.filter_by(
+        setting_name=constants.SETTING_NAME_APP_SECRET
+    ).first()
 
     try:
         decoded_token = jwt.decode(

--- a/application/common/constants.py
+++ b/application/common/constants.py
@@ -1,5 +1,3 @@
-import platform
-
 from datetime import datetime
 from enum import Enum
 
@@ -16,15 +14,15 @@ class FileModes(Enum):
     DIRECTORY = 2
 
 
+SETTING_NAME_STEAM_PATH: str = "steam_install_dir"
+SETTING_NAME_DEFAULT_PATH: str = "default_install_dir"
+SETTING_NAME_APP_SECRET: str = "application_secret"
+
+NUM_SERVER_PROCESSES: int = 2
+
 STARTUP_BATCH_FILE_NAME: str = "startup.bat"
 DEFAULT_SECRET = str(datetime.now())
-
-STARTUP_SETTINGS: dict = {
-    "steam_install_dir": r"C:\STEAM_TEST\steam"
-    if platform.system() == "Windows"
-    else "/opt/steam/steam_cmd",
-    "application_secret": DEFAULT_SECRET,
-}
+GAME_INSTALL_FOLDER = "games"
 
 LOCALHOST_IP_ADDR = "127.0.0.1"
 WAIT_FOR_BACKEND: int = 1

--- a/application/common/game_base.py
+++ b/application/common/game_base.py
@@ -3,7 +3,7 @@ import time
 import shutil
 import subprocess
 
-from application.common import logger
+from application.common import logger, constants
 from application.common.game_argument import GameArgument
 from application.common.exceptions import InvalidUsage
 from application.extensions import DATABASE
@@ -14,7 +14,7 @@ from application.source.models.game_arguments import GameArguments
 class BaseGame:
     DEFAULT_WAIT_PERIOD = 5
 
-    def __init__(self) -> None:
+    def __init__(self, defaults_dict: dict = {}) -> None:
         self._game_args: dict = {}
         self._game_name: str = None
         self._game_pretty_name: str = None
@@ -22,6 +22,14 @@ class BaseGame:
         self._game_steam_id: str = None
         self._game_installed: bool = False
         self._game_info_url: str = ""
+
+        self._defaults = defaults_dict
+        self._game_default_install_dir = None
+
+        if constants.SETTING_NAME_DEFAULT_PATH in self._defaults:
+            self._game_default_install_dir = defaults_dict[
+                constants.SETTING_NAME_DEFAULT_PATH
+            ]
 
     @abc.abstractmethod
     def startup(self) -> None:

--- a/application/common/toolbox.py
+++ b/application/common/toolbox.py
@@ -108,11 +108,11 @@ def _find_conforming_modules(package) -> {}:
 
 
 @staticmethod
-def _instantiate_object(module_name, module):
+def _instantiate_object(module_name, module, defaults_dict={}):
     return_obj = None
     for item in inspect.getmembers(module, inspect.isclass):
         if item[1].__module__ == module_name:
-            return_obj = item[1]()
+            return_obj = item[1](defaults_dict)
     return return_obj
 
 

--- a/application/config/config.py
+++ b/application/config/config.py
@@ -9,7 +9,14 @@ class DefaultConfig:
     # App name and secret
     APP_NAME = "AgentSmith"
     APP_PRETTY_NAME = "Agent Smith"
-    DEPLOYMENT_TYPE = "python"  # also supports kubernetes
+    APP_DEFAULT_SECRET = "super secret!"
+    DEPLOYMENT_TYPE = "python"
+
+    if platform.system() == "Windows":
+        DEFAULT_INSTALL_PATH = f"C:\\{APP_NAME}"
+    else:
+        # TODO - Revisit this when linux support gets closer...
+        DEFAULT_INSTALL_PATH = f"/usr/local/share/{APP_NAME}"
 
     # Flask specific configs
     DEBUG = True
@@ -20,14 +27,14 @@ class DefaultConfig:
 
     # Designate where the database file is stored based on platform.
     if platform.system() == "Windows":
-        base_folder = f"C:\\{APP_NAME}"
+        base_folder = DEFAULT_INSTALL_PATH
         if not os.path.exists(base_folder):
             os.makedirs(base_folder)
         SQLALCHEMY_DATABASE_URI = f"sqlite:///{base_folder}\\{APP_NAME}.db"
     else:
         # Linux
         # Right now, this is for testing since GitHub actions uses linux
-        SQLALCHEMY_DATABASE_URI = f"sqlite:///{APP_NAME}.db"
+        SQLALCHEMY_DATABASE_URI = f"sqlite:///{DEFAULT_INSTALL_PATH}/{APP_NAME}.db"
 
     def __init__(self, deploy_type):
         configuration_options = [el.value for el in _DeployTypes]

--- a/application/factory.py
+++ b/application/factory.py
@@ -83,9 +83,17 @@ def create_app(config=None):
 
     _handle_migrations(flask_app)
 
+    startup_settings: dict = {
+        constants.SETTING_NAME_STEAM_PATH: os.path.join(
+            flask_app.config["DEFAULT_INSTALL_PATH"], "steam"
+        ),
+        constants.SETTING_NAME_DEFAULT_PATH: flask_app.config["DEFAULT_INSTALL_PATH"],
+        constants.SETTING_NAME_APP_SECRET: flask_app.config["APP_DEFAULT_SECRET"],
+    }
+
     # Here just going to initialize some settings. TODO - Make into a function.
     with flask_app.app_context():
-        for setting_name, setting_value in constants.STARTUP_SETTINGS.items():
+        for setting_name, setting_value in startup_settings.items():
             setting_obj = Settings.query.filter_by(setting_name=setting_name).first()
 
             if setting_obj is None:

--- a/application/gui/globals.py
+++ b/application/gui/globals.py
@@ -19,6 +19,7 @@ class GuiGlobals:
         self._server_host: str = "127.0.0.1"
         self._server_port: str = "3000"
         self._steam_install_path: str = "NOT_SET"
+        self._default_install_path: str = "NOT_SET"
 
         # Objects
         self._FLASK_APP: Flask = None

--- a/application/gui/launch.py
+++ b/application/gui/launch.py
@@ -51,7 +51,7 @@ class GuiApp:
     def _spawn_server_on_thread(self):
         self._server_thread = Thread(
             target=lambda: self._globals._FLASK_APP.run(
-                host="0.0.0.0", port=3000, debug=True, use_reloader=False
+                host="0.0.0.0", port=3000, debug=True, use_reloader=False, threaded=True
             )
         )
         self._server_thread.daemon = True

--- a/application/gui/widgets/file_select_widget.py
+++ b/application/gui/widgets/file_select_widget.py
@@ -13,7 +13,11 @@ from operator_client import Operator
 
 class FileSelectWidget(QWidget):
     def __init__(
-        self, client: Operator, file_mode: FileModes, parent: QWidget = None
+        self,
+        client: Operator,
+        file_mode: FileModes,
+        parent: QWidget = None,
+        default_path=None,
     ) -> None:
         super().__init__(parent)
 
@@ -21,6 +25,7 @@ class FileSelectWidget(QWidget):
         self._client = client
         self._file_mode: FileModes = file_mode
         self._selected_path: str = ""
+        self._default_path = default_path
 
         self.init_ui()
 
@@ -49,6 +54,9 @@ class FileSelectWidget(QWidget):
         selector_layout.addWidget(self._browse_button)
 
         self._layout.addLayout(selector_layout)
+
+        if self._default_path:
+            self._path_line_edit.setText(self._default_path)
 
         self.setLayout(self._layout)
 

--- a/application/gui/widgets/settings_widget.py
+++ b/application/gui/widgets/settings_widget.py
@@ -32,8 +32,15 @@ class SettingsWidget(QWidget):
     def init_ui(self):
         self._layout.setAlignment(Qt.AlignTop)
 
-        steam_install_dir = self._client.app.get_setting_by_name("steam_install_dir")
-        application_secret = self._client.app.get_setting_by_name("application_secret")
+        steam_install_dir = self._client.app.get_setting_by_name(
+            constants.SETTING_NAME_STEAM_PATH
+        )
+        default_install_dir = self._client.app.get_setting_by_name(
+            constants.SETTING_NAME_DEFAULT_PATH
+        )
+        application_secret = self._client.app.get_setting_by_name(
+            constants.SETTING_NAME_APP_SECRET
+        )
         self._globals._steam_install_path = steam_install_dir
 
         self.tabs = QTabWidget()
@@ -43,6 +50,9 @@ class SettingsWidget(QWidget):
 
         tab1_layout = QVBoxLayout()
         tab1_layout.addLayout(self._create_steam_path_setting(steam_install_dir))
+        tab1_layout.addLayout(
+            self._create_default_install_path_setting(default_install_dir)
+        )
         tab1_layout.addLayout(self._create_app_secret_setting(application_secret))
         self.tab1.setLayout(tab1_layout)
 
@@ -72,6 +82,21 @@ class SettingsWidget(QWidget):
 
         return h_layout1
 
+    def _create_default_install_path_setting(
+        self, defaut_install_dir: str
+    ) -> QHBoxLayout:
+        h_layout1 = QHBoxLayout()
+        label1 = QLabel("Default Install Path: ")
+        text_edit1 = FileSelectWidget(self._client, constants.FileModes.DIRECTORY, self)
+        text_edit1.get_line_edit().setText(defaut_install_dir)
+        text_edit1.get_line_edit().textChanged.connect(
+            self._update_default_install_path
+        )
+        h_layout1.addWidget(label1)
+        h_layout1.addWidget(text_edit1)
+
+        return h_layout1
+
     def _create_app_secret_setting(self, application_secret: str) -> QHBoxLayout:
         h_layout2 = QHBoxLayout()
         label2 = QLabel("Application Secret: ")
@@ -87,8 +112,16 @@ class SettingsWidget(QWidget):
         logger.info(f"New Steam Install Path: {path}")
         # TODO - Check if this is a path and not something garbage.
         self._globals._steam_install_path = path
-        self._client.app.update_setting_by_name("steam_install_dir", path)
+        self._client.app.update_setting_by_name(constants.SETTING_NAME_STEAM_PATH, path)
+
+    def _update_default_install_path(self, path):
+        logger.info(f"New Default Install Path: {path}")
+        # TODO - Check if this is a path and not something garbage.
+        self._globals._default_install_path = path
+        self._client.app.update_setting_by_name(
+            constants.SETTING_NAME_DEFAULT_PATH, path
+        )
 
     def _update_app_secret(self, text):
         # TODO - Changing the app secret invalidates all existing tokens.
-        self._client.app.update_setting_by_name("application_secret", text)
+        self._client.app.update_setting_by_name(constants.SETTING_NAME_APP_SECRET, text)

--- a/application/source/games/seven_dtd_game.py
+++ b/application/source/games/seven_dtd_game.py
@@ -12,12 +12,10 @@ from application.common.toolbox import _get_proc_by_name, get_resources_dir
 from application.extensions import DATABASE
 from application.source.models.games import Games
 
-# NOTE - This Game is not yet implemented.
-
 
 class SevenDaysToDieGame(BaseGame):
-    def __init__(self) -> None:
-        super(SevenDaysToDieGame, self).__init__()
+    def __init__(self, defaults_dict: dict = {}) -> None:
+        super(SevenDaysToDieGame, self).__init__(defaults_dict)
 
         self._game_name = "7dtd"
         self._game_pretty_name = "7 Days To Die"
@@ -29,6 +27,16 @@ class SevenDaysToDieGame(BaseGame):
 
         self._telnet = Telnet()
 
+        if self._game_default_install_dir:
+            default_config_file_path = os.path.join(
+                self._game_default_install_dir,
+                constants.GAME_INSTALL_FOLDER,
+                self._game_name,
+                "serverconfig.xml",
+            )
+        else:
+            default_config_file_path = None
+
         # Add Args here, can update later.
         self._add_argument(
             GameArgument(
@@ -38,7 +46,7 @@ class SevenDaysToDieGame(BaseGame):
         self._add_argument(
             GameArgument(
                 "ServerConfigFilePath",
-                value=None,
+                value=default_config_file_path,
                 required=True,
                 is_permanent=True,
                 file_mode=constants.FileModes.FILE.value,

--- a/application/source/games/vrising_game.py
+++ b/application/source/games/vrising_game.py
@@ -12,8 +12,8 @@ from application.source.models.games import Games
 
 
 class VrisingGame(BaseGame):
-    def __init__(self) -> None:
-        super(VrisingGame, self).__init__()
+    def __init__(self, defaults_dict: dict = {}) -> None:
+        super(VrisingGame, self).__init__(defaults_dict)
 
         self._game_name = "vrising"
         self._game_pretty_name = "V Rising"
@@ -23,11 +23,28 @@ class VrisingGame(BaseGame):
             "https://github.com/StunlockStudios/vrising-dedicated-server-instructions"
         )
 
+        if self._game_default_install_dir:
+            default_persistent_data_path = os.path.join(
+                self._game_default_install_dir,
+                constants.GAME_INSTALL_FOLDER,
+                self._game_name,
+            )
+            default_log_path = os.path.join(
+                self._game_default_install_dir,
+                constants.GAME_INSTALL_FOLDER,
+                self._game_name,
+                "logs",
+                "vrisinglog.txt",
+            )
+        else:
+            default_persistent_data_path = None
+            default_log_path = None
+
         # Add Args here, can update later.
         self._add_argument(
             GameArgument(
                 "-persistentDataPath",
-                value=None,
+                value=default_persistent_data_path,
                 required=True,
                 is_permanent=True,
                 file_mode=constants.FileModes.DIRECTORY.value,
@@ -36,7 +53,7 @@ class VrisingGame(BaseGame):
         self._add_argument(
             GameArgument(
                 "-serverName",
-                value=None,
+                value="Vrising World",
                 required=True,
                 use_quotes=True,
                 is_permanent=True,
@@ -45,7 +62,7 @@ class VrisingGame(BaseGame):
         self._add_argument(
             GameArgument(
                 "-saveName",
-                value=None,
+                value="AgentSave",
                 required=True,
                 use_quotes=True,
                 is_permanent=True,
@@ -54,7 +71,7 @@ class VrisingGame(BaseGame):
         self._add_argument(
             GameArgument(
                 "-logFile",
-                value=None,
+                value=default_log_path,
                 required=True,
                 use_quotes=True,
                 is_permanent=True,


### PR DESCRIPTION
Now Agent Smith GUI users do not have to provide paths for arguments and installation paths if not desired.  The user may still change those to whatever is desired.   

This helps set up quick installs for the future.