### PR TITLE
Eliminate security vulnerabilty and disable debug /console endpoint.

### DIFF
--- a/application/config/config.py
+++ b/application/config/config.py
@@ -19,8 +19,8 @@ class DefaultConfig:
         DEFAULT_INSTALL_PATH = f"/usr/local/share/{APP_NAME}"
 
     # Flask specific configs
-    DEBUG = True
-    ENV = "development"
+    DEBUG = False
+    ENV = "production"
     FLASK_RUN_HOST = "0.0.0.0"
     FLASK_RUN_PORT = "5000"
     FLASK_FORCE_AUTH = False  # Leave as False except in testing.

--- a/application/gui/launch.py
+++ b/application/gui/launch.py
@@ -56,7 +56,7 @@ class GuiApp:
                 debug=False,
                 use_reloader=False,
                 threaded=True,
-                use_evalex=False
+                use_evalex=False,
             )
         )
         self._server_thread.daemon = True

--- a/application/gui/launch.py
+++ b/application/gui/launch.py
@@ -51,7 +51,12 @@ class GuiApp:
     def _spawn_server_on_thread(self):
         self._server_thread = Thread(
             target=lambda: self._globals._FLASK_APP.run(
-                host="0.0.0.0", port=5000, debug=True, use_reloader=False, threaded=True
+                host="0.0.0.0",
+                port=5000,
+                debug=False,
+                use_reloader=False,
+                threaded=True,
+                use_evalex=False
             )
         )
         self._server_thread.daemon = True


### PR DESCRIPTION
I noticed that leaving the agent-smith.py flask application's flask server running in debug mode allowed the /console route to be accessible.

This corrects a security vulnerability as the /console route is easily "hacked" and would allow someone to gain the ability to run python commands on the host.  

The automatically built agent-smith.exe will now disallow this from happening.