### PR TITLE
Fix SSL issue when using IP address instead of domain name.

### DIFF
--- a/application/source/nginx_manager.py
+++ b/application/source/nginx_manager.py
@@ -136,7 +136,7 @@ class NginxManager:
             self._exe_thread.join()
 
     def _is_string_ip_address(self, s) -> bool:
-        a = s.split('.')
+        a = s.split(".")
         if len(a) != 4:
             return False
         for x in a:


### PR DESCRIPTION
Fixes a case where a user passes an IP address as the server name.  The SAN is now dynamically set to use the correct format depending on whether the input is an IP or a domain name.  Code was added to automatically detect an IP address.  