### PR TITLE
Correct Authorization Logic related to incoming request from nginx reverse proxy

### DIFF
--- a/application/config/nginx/nginx.conf.j2
+++ b/application/config/nginx/nginx.conf.j2
@@ -34,11 +34,15 @@ http {
         ssl_protocols       TLSv1.2 TLSv1.3;
 
         location / {
+
             proxy_pass http://localhost:5000/;
             proxy_buffering off;
+
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Port $server_port;
+
+
 
             # Strictly server requestors using the correct hostname. Bots using IP Addresses
             # not allowed!

--- a/application/source/nginx_manager.py
+++ b/application/source/nginx_manager.py
@@ -136,7 +136,7 @@ class NginxManager:
             self._exe_thread.join()
 
     def _is_string_ip_address(self, s) -> bool:
-        a = s.split('.')
+        a = s.split(".")
         if len(a) != 4:
             return False
         for x in a:


### PR DESCRIPTION
Reverse proxy requests came in to AgentSmith and the incorrect IP address was used for the authorization logic.  An update was made to detect the appropriate header entry, and use the IP forwarded from Nginx. if present.  Also some logic to check that an actor is not spoofing 127.0.0.1 and pretending to be Nginx is in place.

Closes #31 
Relates to #25 