### PR TITLE
Add ability to auto compute checksum and add to release.

### DIFF
--- a/.github/workflows/develop-branch-actions.yml
+++ b/.github/workflows/develop-branch-actions.yml
@@ -67,9 +67,9 @@ jobs:
       run: |
         python package.py
 
-    - name: Run PyInstaller
+    - name: Run Checksum
       run: |
-        python checksum.txt
+        python checksum.py
 
     - name: Upload Exe Build Artifact
       uses: actions/upload-artifact@v3.1.3

--- a/.github/workflows/develop-branch-actions.yml
+++ b/.github/workflows/develop-branch-actions.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Python Black
       uses: psf/black@stable
@@ -60,14 +61,26 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Run PyInstaller
       run: |
         python package.py
 
-    - name: Upload a Build Artifact
+    - name: Run PyInstaller
+      run: |
+        python checksum.txt
+
+    - name: Upload Exe Build Artifact
       uses: actions/upload-artifact@v3.1.3
       with:
         name: AgentSmith-develop
         path: .\dist\agent-smith.exe
+        retention-days: 1
+
+    - name: Upload Checksum Build Artifact
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: AgentSmith-develop-checksum.txt
+        path: checksum.txt
         retention-days: 1

--- a/.github/workflows/every-other-branch-actions.yml
+++ b/.github/workflows/every-other-branch-actions.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Python Black
       uses: psf/black@stable
@@ -64,6 +65,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Run PyInstaller
       run: |

--- a/.github/workflows/main-branch-after-merge-actions.yml
+++ b/.github/workflows/main-branch-after-merge-actions.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Python Black
       uses: psf/black@stable

--- a/.github/workflows/main-branch-after-merge-actions.yml
+++ b/.github/workflows/main-branch-after-merge-actions.yml
@@ -46,6 +46,10 @@ jobs:
       run: |
         python package.py
 
+    - name: Compute Checksum
+      run: |
+        python checksum.py
+
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
@@ -58,4 +62,4 @@ jobs:
         tag: ${{ steps.tag_version.outputs.new_tag }}
         name: Release ${{ steps.tag_version.outputs.new_tag }}
         body: ${{ steps.tag_version.outputs.changelog }}
-        artifacts: .\dist\agent-smith.exe
+        artifacts: .\dist\agent-smith.exe, .\checksum.txt

--- a/.github/workflows/main-branch-pr-actions.yml
+++ b/.github/workflows/main-branch-pr-actions.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Python Black
       uses: psf/black@stable
@@ -58,7 +59,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
 
     - name: Run PyInstaller
       run: |
         python package.py
+
+    - name: Compute Checksum
+      run: |
+        python checksum.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 venv/*
 .env
 *__pycache__*
+checksum.txt
 
 # Database
 instance/*

--- a/checksum.py
+++ b/checksum.py
@@ -1,0 +1,24 @@
+import os
+import hashlib
+
+
+def compute_checksums():
+    dist_path = os.path.join("dist", "agent-smith.exe")
+    checksum_file = "checksum.txt"
+
+    md5_sum = hashlib.md5(open(dist_path, "rb").read()).hexdigest()
+    sha1_sum = hashlib.sha1(open(dist_path, "rb").read()).hexdigest()
+    sha256_sum = hashlib.sha256(open(dist_path, "rb").read()).hexdigest()
+
+    if os.path.exists(checksum_file):
+        os.remove(checksum_file)
+
+    with open(checksum_file, "w") as f:
+        f.write(f"agent-smith.exe\n\n")
+        f.write(f"MD5: {md5_sum}\n")
+        f.write(f"SHA1: {sha1_sum}\n")
+        f.write(f"SHA256: {sha256_sum}\n")
+
+
+if __name__ == "__main__":
+    compute_checksums()

--- a/checksum.py
+++ b/checksum.py
@@ -14,7 +14,7 @@ def compute_checksums():
         os.remove(checksum_file)
 
     with open(checksum_file, "w") as f:
-        f.write(f"agent-smith.exe\n\n")
+        f.write("agent-smith.exe\n\n")
         f.write(f"MD5: {md5_sum}\n")
         f.write(f"SHA1: {sha1_sum}\n")
         f.write(f"SHA256: {sha256_sum}\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 alembic
-black
-coverage
 debugpy
-flake8
 flask
 Flask-SQLAlchemy
 gunicorn
@@ -14,7 +11,6 @@ pyjwt
 pyopenssl
 pyqt5
 pysteamcmd
-pytest
 python-dotenv
 requests
 validators==0.20.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,5 @@
 # TODO - Split requirements.txt file up.
+black
+coverage
+flake8
+pytest


### PR DESCRIPTION
When main branch updates the MD5, SH1, and SHA256 checksums of the agent-smith.exe are computed and added to the release as a text file so users may verify the executable integrity.

Closes #9