### PR TITLE
Fix alembic revision adding non nullable column.

### DIFF
--- a/application/alembic/versions/database_v3.py
+++ b/application/alembic/versions/database_v3.py
@@ -25,10 +25,15 @@ def upgrade():
                 "game_state",
                 sa.String(length=25),
                 default=GameStates.NOT_STATE.value,
-                nullable=False,
+                nullable=True,
             ),
             insert_after="",
             insert_before="",
+        )
+
+        # Set back to nullable and fill with a default value.
+        batch_op.alter_column(
+            "game_state", nullable=False, server_default=GameStates.NOT_STATE.value
         )
 
     # ### end Alembic commands ###

--- a/application/alembic/versions/database_v4.py
+++ b/application/alembic/versions/database_v4.py
@@ -44,10 +44,8 @@ def upgrade():
                 "game_steam_build_branch",
                 sa.String(length=256),
                 default="public",
-                nullable=False,
+                nullable=True,
             ),
-            insert_after="public",
-            insert_before="public",
         )
 
         batch_op.add_column(
@@ -55,10 +53,18 @@ def upgrade():
                 "game_steam_build_id",
                 sa.Integer(),
                 default=-1,
-                nullable=False,
+                nullable=True,
             ),
-            insert_after=-1,
-            insert_before=-1,
+        )
+
+        # Set back to nullable and fill with a default value.
+        batch_op.alter_column(
+            "game_steam_build_branch", nullable=False, server_default="public"
+        )
+
+        # Set back to nullable and fill with a default value.
+        batch_op.alter_column(
+            "game_steam_build_id", nullable=False, server_default="-1"
         )
 
     op.create_index("ix_actions_action_id", "actions", ["action_id"], unique=False)

--- a/application/factory.py
+++ b/application/factory.py
@@ -105,6 +105,8 @@ def create_app(config=None):
 
     _handle_migrations(flask_app)
 
+    return flask_app
+
     startup_settings: dict = {
         constants.SETTING_NAME_STEAM_PATH: os.path.join(
             constants.DEFAULT_INSTALL_PATH, "steam"

--- a/application/models/games.py
+++ b/application/models/games.py
@@ -32,7 +32,7 @@ class Games(PaginatedApi, DATABASE.Model):
         nullable=False,
     )
     game_state = DATABASE.Column(
-        DATABASE.String(25), default=GameStates.NOT_STATE.value, nullable=True
+        DATABASE.String(25), default=GameStates.NOT_STATE.value, nullable=False
     )
 
     actions = DATABASE.relationship(

--- a/application/models/games.py
+++ b/application/models/games.py
@@ -32,7 +32,7 @@ class Games(PaginatedApi, DATABASE.Model):
         nullable=False,
     )
     game_state = DATABASE.Column(
-        DATABASE.String(25), default=GameStates.NOT_STATE.value, nullable=False
+        DATABASE.String(25), default=GameStates.NOT_STATE.value, nullable=True
     )
 
     actions = DATABASE.relationship(


### PR DESCRIPTION
Previously had break from revision to revision because testing was done on a clean database.
When entries were populated between upgrades, revision errors occurred which was never check for prior.

Adding columns to games table that were nullable was not possible because the column had nothing to go in it.  SQL detecting that the column was null while set to non-nullable would error out.

The solution is to allow the column to be null at time of adding it, then go back and set it to non-nullable.

Closes #47