### PR TITLE
Add pytests and test coverage to continuous integration.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+        *__init__*
+        tests\*
+
+[html]
+omit =
+        *__init__*
+        tests\*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
 omit =
         *__init__*
-        tests\*
+        tests/*
+        application/debugger.py
+        application/alembic/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,3 @@
 omit =
         *__init__*
         tests\*
-
-[html]
-omit =
-        *__init__*
-        tests\*

--- a/.github/workflows/develop-branch-actions.yml
+++ b/.github/workflows/develop-branch-actions.yml
@@ -45,6 +45,11 @@ jobs:
         exclude: "tests/*,doc/*,scripts/*"
         max-line-length: "100"
 
+    - name: pytest
+      run: |
+        coverage run -m pytest
+        coverage report --fail-under 50
+
   build_develop_windows_exe:
 
     runs-on: windows-latest

--- a/.github/workflows/develop-branch-actions.yml
+++ b/.github/workflows/develop-branch-actions.yml
@@ -48,7 +48,7 @@ jobs:
     - name: pytest
       run: |
         coverage run -m pytest
-        coverage report --fail-under 50
+        coverage report --fail-under 40
 
   build_develop_windows_exe:
 

--- a/.github/workflows/every-other-branch-actions.yml
+++ b/.github/workflows/every-other-branch-actions.yml
@@ -52,7 +52,7 @@ jobs:
     - name: pytest
       run: |
         coverage run -m pytest
-        coverage report --fail-under 50
+        coverage report --fail-under 40
 
   build_other_windows_exe:
 

--- a/.github/workflows/every-other-branch-actions.yml
+++ b/.github/workflows/every-other-branch-actions.yml
@@ -49,6 +49,11 @@ jobs:
         exclude: "tests/*,doc/*,scripts/*"
         max-line-length: "100"
 
+    - name: Pytest
+      run: |
+        coverage run -m pytest
+        coverage report --fail-under 50
+
   build_other_windows_exe:
 
     runs-on: windows-latest

--- a/.github/workflows/every-other-branch-actions.yml
+++ b/.github/workflows/every-other-branch-actions.yml
@@ -49,7 +49,7 @@ jobs:
         exclude: "tests/*,doc/*,scripts/*"
         max-line-length: "100"
 
-    - name: Pytest
+    - name: pytest
       run: |
         coverage run -m pytest
         coverage report --fail-under 50

--- a/.github/workflows/main-branch-after-merge-actions.yml
+++ b/.github/workflows/main-branch-after-merge-actions.yml
@@ -46,7 +46,7 @@ jobs:
     - name: pytest
       run: |
         coverage run -m pytest
-        coverage report --fail-under 50
+        coverage report --fail-under 40
 
     - name: Run PyInstaller
       run: |

--- a/.github/workflows/main-branch-after-merge-actions.yml
+++ b/.github/workflows/main-branch-after-merge-actions.yml
@@ -43,6 +43,11 @@ jobs:
         exclude: "tests/*,doc/*,scripts/*"
         max-line-length: "100"
 
+    - name: pytest
+      run: |
+        coverage run -m pytest
+        coverage report --fail-under 50
+
     - name: Run PyInstaller
       run: |
         python package.py

--- a/.github/workflows/main-branch-pr-actions.yml
+++ b/.github/workflows/main-branch-pr-actions.yml
@@ -46,7 +46,7 @@ jobs:
     - name: pytest
       run: |
         coverage run -m pytest
-        coverage report --fail-under 50
+        coverage report --fail-under 40
 
   build_main_pr_windows_exe:
 

--- a/.github/workflows/main-branch-pr-actions.yml
+++ b/.github/workflows/main-branch-pr-actions.yml
@@ -43,6 +43,11 @@ jobs:
         exclude: "tests/*,doc/*,scripts/*"
         max-line-length: "100"
 
+    - name: pytest
+      run: |
+        coverage run -m pytest
+        coverage report --fail-under 50
+
   build_main_pr_windows_exe:
 
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Hidden folder/file types.
 .coverage
+htmlcov/
 venv/*
 .env
 *__pycache__*

--- a/application/common/authorization.py
+++ b/application/common/authorization.py
@@ -7,6 +7,18 @@ from application.models.settings import Settings
 from application.models.tokens import Tokens
 
 
+def _get_token(bearer_token: str) -> Tokens:
+    token_lookup = Tokens.query.filter_by(
+        token_active=True, token_value=bearer_token
+    ).first()
+    return token_lookup
+
+
+def _get_setting(setting_name: str) -> Settings:
+    setting_lookup = Settings.query.filter_by(setting_name=setting_name).first()
+    return setting_lookup
+
+
 def _verify_bearer_token(request: Request) -> int:
     """This is the bearer token gauntlet.
     The requests only goal is to get through all of the checks.
@@ -25,17 +37,13 @@ def _verify_bearer_token(request: Request) -> int:
     bearer_token = auth.split("Bearer")[-1].strip()
 
     # Make sure it's there first...
-    token_lookup = Tokens.query.filter_by(
-        token_active=True, token_value=bearer_token
-    ).first()
+    token_lookup = _get_token(bearer_token)
 
     if token_lookup is None:
         return 403
 
     # Next decode this bad thing...
-    secret_obj = Settings.query.filter_by(
-        setting_name=constants.SETTING_NAME_APP_SECRET
-    ).first()
+    secret_obj = _get_setting(constants.SETTING_NAME_APP_SECRET)
 
     try:
         decoded_token = jwt.decode(

--- a/application/common/steam_manifest_parser.py
+++ b/application/common/steam_manifest_parser.py
@@ -6,7 +6,9 @@ def read_dir(dir: str):
 
     for file in os.listdir(dir):
         if file.endswith(".acf"):
-            acf = read_acf(dir + file)
+            # acf = read_dir(dir)
+            acf = read_acf(os.path.join(dir, file))
+            # acf = read_acf(dir + file)
             steamapps[acf["appid"]] = acf
 
     return steamapps

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -1,0 +1,2 @@
+coverage run -m pytest
+coverage report

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ black
 coverage
 flake8
 pytest
+pytest-mock

--- a/tests/functional/test_settings_api.py
+++ b/tests/functional/test_settings_api.py
@@ -1,6 +1,6 @@
 import os
 
-from application.source.models.settings import Settings
+from application.models.settings import Settings
 
 
 class TestAppSettingsApi:

--- a/tests/unit/resources/appmanifest_1829350.acf
+++ b/tests/unit/resources/appmanifest_1829350.acf
@@ -1,0 +1,43 @@
+"AppState"
+{
+	"appid"		"1829350"
+	"Universe"		"1"
+	"LauncherPath"		"C:\\AgentSmith\\steam\\steamcmd.exe"
+	"name"		"V Rising Dedicated Server"
+	"StateFlags"		"4"
+	"installdir"		"VRisingDedicatedServer"
+	"LastUpdated"		"1710615232"
+	"LastPlayed"		"0"
+	"SizeOnDisk"		"1453745726"
+	"StagingSize"		"0"
+	"buildid"		"12520643"
+	"LastOwner"		"76561200388861161"
+	"UpdateResult"		"0"
+	"BytesToDownload"		"213631952"
+	"BytesDownloaded"		"213631952"
+	"BytesToStage"		"1453745726"
+	"BytesStaged"		"1453745726"
+	"TargetBuildID"		"12520643"
+	"AutoUpdateBehavior"		"0"
+	"AllowOtherDownloadsWhileRunning"		"0"
+	"ScheduledAutoUpdate"		"0"
+	"InstalledDepots"
+	{
+		"1004"
+		{
+			"manifest"		"1923798258558304932"
+			"size"		"44194776"
+		}
+		"1829351"
+		{
+			"manifest"		"5850011680124575304"
+			"size"		"1409550950"
+		}
+	}
+	"UserConfig"
+	{
+	}
+	"MountedConfig"
+	{
+	}
+}

--- a/tests/unit/resources/steam_manifest/appmanifest_1829350.acf
+++ b/tests/unit/resources/steam_manifest/appmanifest_1829350.acf
@@ -1,0 +1,43 @@
+"AppState"
+{
+	"appid"		"1829350"
+	"Universe"		"1"
+	"LauncherPath"		"C:\\AgentSmith\\steam\\steamcmd.exe"
+	"name"		"V Rising Dedicated Server"
+	"StateFlags"		"4"
+	"installdir"		"VRisingDedicatedServer"
+	"LastUpdated"		"1710615232"
+	"LastPlayed"		"0"
+	"SizeOnDisk"		"1453745726"
+	"StagingSize"		"0"
+	"buildid"		"12520643"
+	"LastOwner"		"76561200388861161"
+	"UpdateResult"		"0"
+	"BytesToDownload"		"213631952"
+	"BytesDownloaded"		"213631952"
+	"BytesToStage"		"1453745726"
+	"BytesStaged"		"1453745726"
+	"TargetBuildID"		"12520643"
+	"AutoUpdateBehavior"		"0"
+	"AllowOtherDownloadsWhileRunning"		"0"
+	"ScheduledAutoUpdate"		"0"
+	"InstalledDepots"
+	{
+		"1004"
+		{
+			"manifest"		"1923798258558304932"
+			"size"		"44194776"
+		}
+		"1829351"
+		{
+			"manifest"		"5850011680124575304"
+			"size"		"1409550950"
+		}
+	}
+	"UserConfig"
+	{
+	}
+	"MountedConfig"
+	{
+	}
+}

--- a/tests/unit/test_authorization.py
+++ b/tests/unit/test_authorization.py
@@ -1,0 +1,45 @@
+from application.common import authorization
+
+
+class FakeRequest:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+class FakeToken:
+    def __init__(self) -> None:
+        self.token_name = "foo"
+
+
+class FakeSetting:
+    def __init__(self) -> None:
+        self.setting_value = "bar"
+
+
+class TestAuthorization:
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def test_verify_bearer_token(self, mocker):
+        # Arrange
+        fake_headers = {"Authorization": "Bearer 1234"}
+        fake_request = FakeRequest(headers=fake_headers)
+        fake_token = FakeToken()
+        fake_setting = FakeSetting()
+
+        mocker.patch(
+            "application.common.authorization._get_token", return_value=fake_token
+        )
+        mocker.patch(
+            "application.common.authorization._get_setting", return_value=fake_setting
+        )
+        mocker.patch("jwt.decode", return_value={"token_name": "foo"})
+
+        return_code = authorization._verify_bearer_token(fake_request)
+
+        assert return_code == 200

--- a/tests/unit/test_steam_parser.py
+++ b/tests/unit/test_steam_parser.py
@@ -1,0 +1,35 @@
+import os
+
+from application.common.steam_manifest_parser import read_acf, parser, read_dir
+
+
+class TestSteamManifestParser:
+    ACF_FILE_NAME = "appmanifest_1829350.acf"
+    ACF_FILE_PATH = ""
+    ACF_FOLDER = ""
+
+    @classmethod
+    def setup_class(cls):
+        # Get the current working directory
+        current_location = os.path.abspath(__file__)
+        current_folder = os.path.dirname(current_location)
+        cls.ACF_FOLDER = os.path.join(current_folder, "resources", "steam_manifest")
+        cls.ACF_FILE_PATH = os.path.join(
+            current_folder, "resources", "steam_manifest", cls.ACF_FILE_NAME
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def test_read_dir(self):
+        steamapps = read_dir(self.ACF_FOLDER)
+        assert len(steamapps) == 1
+        assert "1829350" in steamapps
+
+    def test_read_acf(self):
+        acf = read_acf(self.ACF_FILE_PATH)
+        assert acf["appid"] == "1829350"
+        assert acf["name"] == "V Rising Dedicated Server"
+        assert acf["StateFlags"] == "4"
+        assert acf["installdir"] == "VRisingDedicatedServer"


### PR DESCRIPTION
Add continuous integration for pytests.  Coverage at 40% or better now enforced. 

Resolves #52 