### PR TITLE
Fix several bugs found in production

### DIFF
--- a/application/common/game_base.py
+++ b/application/common/game_base.py
@@ -26,6 +26,10 @@ class BaseGame:
         self._defaults = defaults_dict
         self._game_default_install_dir = None
 
+        # Whether or not users are alloed to add additional args.
+        # Allowed by default. Game implementations will have to disable it.
+        self._allow_user_args = True
+
         if constants.SETTING_NAME_DEFAULT_PATH in self._defaults:
             self._game_default_install_dir = defaults_dict[
                 constants.SETTING_NAME_DEFAULT_PATH

--- a/application/common/toolbox.py
+++ b/application/common/toolbox.py
@@ -1,6 +1,7 @@
 import os
 import inspect
 import importlib.util
+import platform
 import psutil
 import sys
 
@@ -179,3 +180,11 @@ def update_game_state(game_data: dict, new_state: GameStates) -> True:
         update_success = False
 
     return update_success
+
+
+@staticmethod
+def _correct_path(path_value):
+    fixed_path = ""
+    if platform.system() == "Windows":
+        fixed_path = path_value.replace("/", "\\")
+    return fixed_path

--- a/application/games/seven_dtd_game.py
+++ b/application/games/seven_dtd_game.py
@@ -53,6 +53,9 @@ class SevenDaysToDieGame(BaseGame):
             )
         )
 
+        # The user may not add additional arguments for this game server.
+        self._allow_user_args = False
+
     def startup(self) -> None:
         # Run base class checks
         # Run base class checks

--- a/application/gui/widgets/file_select_widget.py
+++ b/application/gui/widgets/file_select_widget.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QFont, QFontMetrics
 
+from application.common import toolbox
 from application.common.constants import FileModes
 from operator_client import Operator
 
@@ -74,7 +75,7 @@ class FileSelectWidget(QWidget):
             )
 
         if path:
-            self._path_line_edit.setText(path)
+            self._path_line_edit.setText(toolbox._correct_path(path))
 
     def _resize_to_content(self):
         text = self._path_line_edit.text()

--- a/application/gui/widgets/game_arguments_widget.py
+++ b/application/gui/widgets/game_arguments_widget.py
@@ -27,14 +27,23 @@ class GameArgumentsWidget(QWidget):
     ARG_ACTION_COL = 3
 
     def __init__(
-        self, client: Operator, arg_data: dict, parent: QWidget, disable_cols: list = []
+        self,
+        client: Operator,
+        arg_data: dict,
+        parent: QWidget,
+        disable_cols: list = [],
+        built_in_args=None,
     ) -> None:
         super(QWidget, self).__init__(parent)
 
         self._parent = parent
         self._client = client
         self._layout = QVBoxLayout()
+        # Args that the game has built in + args the user added.
         self._arg_data = arg_data
+        # Args that the game has built in
+        self._built_in_args = built_in_args
+        # Args on this widget
         self._args_dict: dict = {}
         self._disable_cols = disable_cols
 
@@ -131,9 +140,21 @@ class GameArgumentsWidget(QWidget):
                 elif c == self.ARG_REQUIRED_COL:
                     if "Required" in self._disable_cols:
                         continue
-                    required_cb = QCheckBox()
-                    required_cb.setChecked(True if arg_required == 1 else False)
-                    self._table.setCellWidget(r, c, required_cb)
+                    # If provided built in args list... check if arg is in that list.
+                    if self._built_in_args:
+                        required_cb = QCheckBox()
+                        required_cb.setChecked(True if arg_required == 1 else False)
+                        self._table.setCellWidget(r, c, required_cb)
+
+                        # disable the checkbox if the arg isn't in that place.
+                        if arg_name not in self._built_in_args:
+                            required_cb.setDisabled(True)
+
+                    else:
+                        # otherwise... Just add a checkbox
+                        required_cb = QCheckBox()
+                        required_cb.setChecked(True if arg_required == 1 else False)
+                        self._table.setCellWidget(r, c, required_cb)
                 elif c == self.ARG_ACTION_COL:
                     if "Actions" in self._disable_cols:
                         continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 alembic
 concurrent-log-handler
-debugpy
-flask
-Flask-SQLAlchemy
+flask==3.0.0
+Flask-SQLAlchemy==3.1.1
 gunicorn
 oauthlib
 psutil

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 # TODO - Split requirements.txt file up.
 black
 coverage
+debugpy
 flake8
 pytest
 pytest-mock


### PR DESCRIPTION
Bugs fixed:
1. Resolves #78 - Removed option to create a new argument and make it required.  Users should not be able to add a required argument.
2. Resolves #79 - Devs can now block users from adding any arguments for a given game server implementation.
3. Resolves #74 - Correct linux paths from showing up on windows in the new argument window/widget.
4. Resolves #76 - Fix duplicate arguments adding while adding a single argument.  There was an issue where the Game Manager windows refreshing itself would cause a delay which resulted in the duplication.

Other fixes:
* Decreased refresh interval on Game Manager window from 15 to 6 seconds.